### PR TITLE
Fix the bug with the Jupyter Notebook version before merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,24 @@
 # Welcome to DataJoint tutorials!
 
-DataJoint is an open-source library for science labs to design and build data pipelines for automated data analysis and sharing.
+DataJoint is an open-source library for scientific research labs to design and build
+data pipelines for automated data analysis and sharing.
 
-This document will guide you as a new DataJoint user through interactive tutorials organized in [Jupyter notebooks](https://jupyter-notebook.readthedocs.io/en/stable/) and written in [Python](https://www.python.org/).
+This document will guide you through interactive tutorials written in
+[Python](https://www.python.org/) and organized in [Jupyter
+notebooks](https://jupyter-notebook.readthedocs.io/en/stable/).
 
 *Please note that these hands-on DataJoint tutorials are friendly to non-expert users, and advanced programming skills are not required.* 
 
 
 ## Table of contents 
-- In the [tutorials](./tutorials) folder are interactive Jupyter notebooks to learn DataJoint. The calcium imaging and electrophysiology tutorials provide examples of defining and interacting with data pipelines. In addition, some fill-in-the-blank sections are included for you to code yourself!
+- The [tutorials](./tutorials) folder contains interactive Jupyter notebooks designed to teach DataJoint. The calcium imaging and electrophysiology tutorials provide examples of defining and interacting with data pipelines. In addition, some fill-in-the-blank sections are included for you to code yourself!
     - 01-DataJoint Basics
     - 02-Calcium Imaging Imported Tables
     - 03-Calcium Imaging Computed Tables
     - 04-Electrophysiology Imported Tables
     - 05-Electrophysiology Computed Tables
 
-- In the [completed_tutorials](./completed_tutorials) folder are Jupyter notebooks with the code sections completed and solved.
+- The [completed_tutorials](./completed_tutorials) folder contains Jupyter notebooks with all code sections completed and solved.
 
 - You will find the following notebooks in the [short_tutorials](./short_tutorials) folder:
     - DataJoint in 30min

--- a/tutorials/01-DataJoint Basics.ipynb
+++ b/tutorials/01-DataJoint Basics.ipynb
@@ -84,7 +84,6 @@
     ">* Nodes in this graph are represented as database **tables**. Examples of such tables include \"Subject\", \"Session\", \"Implantation\", \"Experimenter\", \"Equipment\", but also \"OptoWaveform\", \"OptoStimParams\", or \"Neuronal spikes\".  \n",
     "\n",
     ">* The data pipeline is formed by making these tables interdependent (as the nodes are connected in a network). A **dependency** is a situation where a step of the data pipeline is dependent on a result from a sequentially previous step before it can complete its execution. A dependency graph forms an entire cohesive data pipeline. \n",
-    "While this is an accurate description, it may not be the most intuitive definition. Put succinctly, a data pipeline is a listing or a \"map\" of various \"things\" that you work with in a project, with line connecting things to each other to indicate their dependencies. The \"things\" in a data pipeline tends to be the *nouns* you find when describing a project. The \"things\" may include anything from mouse, experimenter, equipment, to experiment session, trial, two-photon scans, electric activities, to receptive fields, neuronal spikes, to figures for a publication! A data pipeline gives you a framework to:\n",
     "\n",
     "A [DataJoint pipeline](https://datajoint.com/docs/core/datajoint-python/0.14/concepts/terminology/) contains database table definitions, dependencies, and associated computations, together with the transformations underlying a DataJoint workflow. \n",
     "\n",
@@ -102,7 +101,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Practical examples"
+    "##### Practical examples"
    ]
   },
   {
@@ -172,7 +171,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Just by going through the description, we can start to identify **entities** that need to be stored and represented in our data pipeline:\n",
+    "Just by going through the description, we can start to identify **entities** that needs to be stored and represented in our data pipeline:\n",
     "\n",
     ">* Mouse\n",
     ">* Experimental session\n",
@@ -207,7 +206,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Concepts"
+    "##### Concepts"
    ]
   },
   {
@@ -222,7 +221,7 @@
     "\n",
     "In this case, the information that uniquely identifies the `Mouse` table is their **mouse IDs** - a unique ID number assigned to each animal in the lab. This attribute is named the **primary key** of the table.\n",
     "\n",
-    "| mouse_id* (*Primary key attribute*)|\n",
+    "| Mouse_ID (*Primary key attribute*)|\n",
     "|:--------: |                         \n",
     "| 11234     |\n",
     "| 11432     |"
@@ -234,11 +233,11 @@
    "source": [
     "After some thought, we might conclude that each mouse can be uniquely identified by knowing its **mouse ID** - a unique ID number assigned to each mouse in the lab. \n",
     "\n",
-    "The `mouse_id` is then a column in the table or an **attribute** that can be used to **uniquely identify** each mouse. \n",
+    "The mouse ID is then a column in the table or an **attribute** that can be used to **uniquely identify** each mouse. \n",
     "\n",
     "Such an attribute is called the **primary key** of the table: the subset of table attributes uniquely identifying each entity in the table. The **secondary attribute** refers to any field in a table, not in the primary key.\n",
     "\n",
-    "| mouse_id* (*Primary key attribute*) \n",
+    "| Mouse_ID (*Primary key attribute*) \n",
     "|:--------:|  \n",
     "| 11234      (*Secondary attribute*)\n",
     "| 11432      (*Secondary attribute*)"
@@ -248,7 +247,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Once we have successfully identified the table's primary key, we can now think about what other columns, or **non-primary key attributes** - additional information **about each entry in the table that needs to be stored as well**."
+    "Once we have successfully identified the table's primary key, we can now think about what other columns, or **non-primary key attributes** - additional information **about each entry in the table that need to be stored as well**."
    ]
   },
   {
@@ -264,7 +263,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "| mouse_id* | dob        | sex |\n",
+    "| Mouse_ID | DOB        | sex |\n",
     "|:--------:|------------|--------|\n",
     "| 11234    | 2017-11-17 | M      |\n",
     "| 11432    | 2018-03-04 | F      |"
@@ -281,14 +280,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Practical example"
+    "##### Practical example"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Schema"
+    "##### Schema"
    ]
   },
   {
@@ -326,14 +325,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Table"
+    "##### Table"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In DataJoint, you define each table as a `class`, and provide the table definition (e.g. attribute definitions) as the `definition` static string property. The class will inherit from the `dj.Manual` class provided by DataJoint (more on this later)."
+    "In DataJoint, you define each table as a `class`, and provide the table definition (e.g., attribute definitions) as the `definition` static string property. The class will inherit from the `dj.Manual` class provided by DataJoint (more on this later)."
    ]
   },
   {
@@ -380,7 +379,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Insert operators"
+    "##### Insert operators"
    ]
   },
   {
@@ -520,7 +519,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Data integrity"
+    "##### Data integrity"
    ]
   },
   {
@@ -608,7 +607,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As with `mouse`, we should consider **what information (i.e. attributes) is needed to identify an `experimental session`** uniquely. Here is the relevant section of the project description:\n",
+    "As with `mouse`, we should consider **what information (i.e., attributes) is needed to identify an `experimental session`** uniquely. Here is the relevant section of the project description:\n",
     "\n",
     "> * As a hard-working neuroscientist, you perform experiments daily, sometimes working with **more than one mouse in a day**. However, on any given day, **a mouse undergoes at most one recording session**.\n",
     "> * For each **experimental session**, you want to record **what mouse you worked with** and **when you performed the experiment**. You also want to keep track of other helpful information, such as the **experimental setup** you worked on.  "
@@ -618,7 +617,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Based on the above, you need to know the following information to uniquely identify a single experimental session:\n",
+    "Based on the above, it seems that you need to know these two data to uniquely identify a single experimental session:\n",
     "\n",
     "* the date of the session\n",
     "* the mouse you recorded from in that session"
@@ -628,7 +627,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that to uniquely identify an experimental session (or simply a **session**), we need to know the mouse used in that session. In other words, a session cannot exist without a corresponding mouse! \n",
+    "Note that, to uniquely identify an experimental session (or simply a `Session`), we need to know the mouse that the session was about. In other words, a session cannot existing without a corresponding mouse! \n",
     "\n",
     "With **mouse** already represented as a table in our pipeline, we say that the session **depends on** the mouse! We could graphically represent this in an **entity relationship diagram (ERD)** by drawing the line between two tables, with the one below (**session**) depending on the one above (**mouse**)."
    ]
@@ -639,7 +638,7 @@
    "source": [
     "Thus, we will need both the **mouse** and the new attribute **session_date** to identify a single `session` uniquely. \n",
     "\n",
-    "Remember that a **mouse** is already uniquely identified by its primary key - **mouse_id**. In DataJoint, you can declare that **session** depends on the mouse, and DataJoint will automatically include the mouse's primary key (`mouse_id`) as part of the session's primary key, along side any additional attribute(s) you specify."
+    "Remember that a **mouse** is uniquely identified by its primary key - **mouse_id**. In DataJoint, you can declare that **session** depends on the mouse, and DataJoint will automatically include the mouse's primary key (`mouse_id`) as part of the session's primary key, alongside any additional attribute(s) you specify."
    ]
   },
   {
@@ -828,10 +827,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will introduce the major types of queries used in DataJoint:\n",
-    "1. Restriction (`&`) and negative restriction (`-`): filter the data with certain conditions\n",
-    "2. Join (`*`): bring fields from different tables together\n",
-    "3. Projection (`.proj()`): focus on a subset of attributes\n",
+    "We will introduce significant types of queries used in DataJoint:\n",
+    "* 1. Restriction (`&`) and negative restriction (`-`): filter the data with certain conditions\n",
+    "* 2. Join (`*`): bring fields from different tables together\n",
+    "* 3. Projection (`.proj()`): focus on a subset of attributes\n",
+    "* 4. Fetch (`.fetch()`): pull the data from the database\n",
+    "* 5. Deletion (`.delete()`): delete entries and their dependencies\n",
+    "* 6. Drop (`.drop()`): drop the table from the schema"
    ]
   },
   {
@@ -852,7 +854,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Exact match"
+    "##### Exact match"
    ]
   },
   {
@@ -1017,7 +1019,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The result of one query can be used in another query! Let's first find **all the female mice** and store the result:"
+    "The result of one query can be used in another query! Let's first find `all the female mice` and `store the result`:"
    ]
   },
   {
@@ -1348,7 +1350,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Fetch it:"
+    "Fetch it!:"
    ]
   },
   {
@@ -1609,7 +1611,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that the `.delete()` method not only deletes the entries in the table where it is called, but also all the corresponding entries in subsequent (downstream) tables!"
+    "Note that the `.delete()` method not only delete the entries in a table, but also all the corresponding entries in subsequent (downstream) tables!"
    ]
   },
   {

--- a/tutorials/02-Calcium Imaging Imported Tables.ipynb
+++ b/tutorials/02-Calcium Imaging Imported Tables.ipynb
@@ -19,7 +19,7 @@
     "During this session you will learn:\n",
     "\n",
     "* To import neuron imaging data from data files into an `Imported` table\n",
-    "* To automatically trigger data importing and computations for all the missing entries with `populate`"
+    "* To automatically trigger data importing and computations for all the missing entries with `Populate`"
    ]
   },
   {
@@ -33,7 +33,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First things first, let's import `DataJoint` again."
+    "First thing first, let's import `DataJoint` again."
    ]
   },
   {
@@ -74,11 +74,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the `data` folder in this repository, you will find a small dataset of three different calcium imaging scans named `example_scan_02.tif`, `example_scan_03.tif`and `example_scan_01.tif`.\n",
+    "In the `data` folder in this `DataJoint-Tutorials`, you can find a small dataset of three different cases of calcium imaging scans: `example_scan_02.tif`, `example_scan_03.tif`and `example_scan_01.tif`.\n",
     "\n",
     "As you might know, calcium imaging scans (raw data) are stored as *.tif* files. \n",
     "\n",
-    "*NOTE: For this tutorial there is no need to deeply explore this dataset. Nevertheless, if you are curious about visualizing these example scans, we recommend you to open the TIFF with [ImageJ](https://imagej.nih.gov/ij/download.html).*"
+    "*NOTE: For this tutorial there is no need to deeper explore this small dataset. Nevertheless, if you are curious about visualizing these example scans, we recommend you to open the TIFF with [ImageJ](https://imagej.nih.gov/ij/download.html).*"
    ]
   },
   {
@@ -92,7 +92,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "DataJoint pipelines commonly start with tables for `Mouse` and `Session`. Let's quickly create these tables based on what we learned in the previous session:"
+    "The DataJoint pipeline commonly starts with a `schema` and the following classes for each table: `Mouse` and `Session`. Let's quickly create this pipeline's first steps as we learned it in the previous session:"
    ]
   },
   {
@@ -320,10 +320,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This tiff file contains 100 frames. \n",
+    "Particularly, this example contains 100 frames. \n",
     "\n",
-    "Let's calculate the average of the images over the frames and plot the result.\n",
-    "\n"
+    "Let's calculate the average of the images over the frames and plot the result.\n"
    ]
   },
   {
@@ -402,7 +401,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We defined `average_frame` as a `longblob`, which allows us to store a NumPy array. This NumPy array will be imported and computed from the file corresponding to each scan."
+    "We defined `average_frame` as a `longblob`, which allow us to store a NumPy array. This NumPy array will be imported and computed from the file corresponding to each scan."
    ]
   },
   {
@@ -425,7 +424,7 @@
    "source": [
     "In DataJoint, the tier of the table indicates **the nature of the data and the data source for the table**. So far we have encountered two table tiers: `Manual` and `Imported`, and we will encounter the two other major tiers in this session. \n",
     "\n",
-    "DataJoint tables in `Manual` tier, or simply **Manual tables** indicate that its contents are **manually** entered by either experimenters or a recording system, and its content **do not depend on external data files or other tables**. This is the most basic table type you will encounter, especially as the tables at the beginning of the pipeline. In the Diagram, `Manual` tables are depicted by green rectangles.\n",
+    "DataJoint tables in `Manual` tier, or simply **Manual tables** indicate that its contents are **manually** entered by either experimenters or a recording system, and its content **do not depend on external data files or other tables**. This is the most basic table type you will encounter, especially as the tables at the beginning of the pipeline. In the diagram, `Manual` tables are depicted by green rectangles.\n",
     "\n",
     "On the other hand, **Imported tables** are understood to pull data (or *import* data) from external data files, and come equipped with functionalities to perform this importing process automatically, as we will see shortly! In the Diagram, `Imported` tables are depicted by blue ellipses."
    ]
@@ -450,7 +449,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Rather than filling out the content of the table manually using `insert1` or `insert` methods, we are going to make use of the `make` and `populate` logic that comes with `Imported` tables to automatically figure out what needs to be imported and perform the import."
+    "Rather than filling out the content of the table manually using `insert1` or `insert` methods, we are going to make use of the `make` and `populate` logic that comes with `Imported` tables. These two methods automatically figure it out what needs to be imported, and perform the import."
    ]
   },
   {
@@ -464,7 +463,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`Imported` tables come with a special method called `populate`. Let's call it for `AverageFrame`:\n",
+    "`Imported` table comes with a special method called `populate`. Let's call it for `AverageFrame`:\n",
     "\n",
     "*Note that the following code line is intended to generate a code error.*"
    ]


### PR DESCRIPTION
This minor pull request addresses an issue that arose in the Jupyter Notebook within [this pull request](https://github.com/datajoint/datajoint-tutorials/pull/36) following the final round of reviews: `Error: The base notebook is not valid. We have compared the head notebook with an empty notebook.`

Here's what was done in this minor PR:

- [x] A new branch named `fix_update_tutorial` was created in my fork based on the [latest commit](https://github.com/datajoint/datajoint-tutorials/pull/36/commits/85dd9fcf1c529db31e26b0c9caf003ba21d4be2f), just before the minor changes made in [PR #1 ](https://github.com/MilagrosMarin/datajoint-tutorials/pull/1).  
- [x] The changes marked as 'reverted' in that pull request were manually integrated here.
- [x] I have tested running the notebook in a codespace, and it was successful

Upon merging this minor PR into [the main PR](https://github.com/datajoint/datajoint-tutorials/pull/36), it will undergo a final review as part of the update process.